### PR TITLE
Fix mysql-dump job.

### DIFF
--- a/labs/10_data/job_mysql-dump.yaml
+++ b/labs/10_data/job_mysql-dump.yaml
@@ -3,7 +3,6 @@ kind: Job
 metadata:
   name: mysql-dump
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     spec:
       containers:
@@ -14,10 +13,10 @@ spec:
         - '-eo'
         - 'pipefail'
         - '-c'
-        - > 
-          trap "echo Backup failed; exit 0" ERR; 
+        - >
+          trap "echo Backup failed; exit 0" ERR;
           FILENAME=backup-${MYSQL_DATABASE}-`date +%Y-%m-%d_%H%M%S`.sql.gz;
-          mysqldump --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --host=${MYSQL_HOST} --port=${MYSQL_PORT} --skip-lock-tables --quick --add-drop-database --routines ${MYSQL_DATABASE} | gzip > /tmp/$FILENAME); 
+          mysqldump --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --host=${MYSQL_HOST} --port=${MYSQL_PORT} --skip-lock-tables --quick --add-drop-database --routines ${MYSQL_DATABASE} | gzip > /tmp/$FILENAME);
           echo "";
           echo "Backup successful"; du -h /tmp/$FILENAME;
         env:
@@ -28,7 +27,7 @@ spec:
         - name: MYSQL_HOST
           value: springboot-mysql
         - name: MYSQL_PORT
-          value: 3306
+          value: "3306"
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Remove `ttlSecondsAfterFinished`, which does not exist on Kubernetes 1.9.
Add missing quotes for MySQL port, env vars are strings.