### PR TITLE
update 06_scale.md

### DIFF
--- a/labs/06_scale.md
+++ b/labs/06_scale.md
@@ -116,7 +116,7 @@ Ersetzen Sie dafür `[ip]` mit Ihrer definierten External IP:
 
 ```
 Linux:
-while true; do sleep 1; curl -s http://[ip]/pod/; date "+ TIME: %H:%M:%S,%3N"; done
+while true; do sleep 1; curl -s http://[LoadBalance Ingress ip]/; date "+ TIME: %H:%M:%S,%3N"; done
 ```
 
 ```

--- a/labs/06_scale.md
+++ b/labs/06_scale.md
@@ -116,7 +116,7 @@ Ersetzen Sie dafür `[ip]` mit Ihrer definierten External IP:
 
 ```
 Linux:
-while true; do sleep 1; curl -s http://[LoadBalance Ingress ip]/; date "+ TIME: %H:%M:%S,%3N"; done
+while true; do sleep 1; curl -s http://[LoadBalance Ingress ip]/pod/; date "+ TIME: %H:%M:%S,%3N"; done
 ```
 
 ```


### PR DESCRIPTION
`while  true; do sleep 1; curl -s http://[ip]/pod/; date "+ TIME: %H:%M:%S,%3N"; done` is failing, but if Ingress Cluster ip is chosen, than it works.
`while  true; do sleep 1; curl -s http://[Ingress Cluster ip]/; date`