### PR TITLE
Remove additional parenthesis mysqldump

### DIFF
--- a/labs/10_data/job_mysql-dump.yaml
+++ b/labs/10_data/job_mysql-dump.yaml
@@ -16,7 +16,7 @@ spec:
         - >
           trap "echo Backup failed; exit 0" ERR;
           FILENAME=backup-${MYSQL_DATABASE}-`date +%Y-%m-%d_%H%M%S`.sql.gz;
-          mysqldump --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --host=${MYSQL_HOST} --port=${MYSQL_PORT} --skip-lock-tables --quick --add-drop-database --routines ${MYSQL_DATABASE} | gzip > /tmp/$FILENAME);
+          mysqldump --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --host=${MYSQL_HOST} --port=${MYSQL_PORT} --skip-lock-tables --quick --add-drop-database --routines ${MYSQL_DATABASE} | gzip > /tmp/$FILENAME;
           echo "";
           echo "Backup successful"; du -h /tmp/$FILENAME;
         env:


### PR DESCRIPTION
When running the [Create a Job][1] techlab an error occurred:

```
ME                                   READY     STATUS    RESTARTS   AGE
mysql-dump-8whd8                       0/1       Error     0          118s
```

In the `kubectl log` we got that error:

```
$ kubectl logs -f mysql-dump-cdbzt
bash: -c: line 0: syntax error near unexpected token `)'
```

Additional parenthesis removed and afterward it worked.

[1]: https://github.com/puzzle/kubernetes-techlab/blob/rancherversion/labs/10_3_jobs.md#task-lab101-create-a-job-for-a-mysql-dump